### PR TITLE
fix(satellite): Oak audit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,8 +48,8 @@ dependencies = [
 
 [[package]]
 name = "astroport"
-version = "2.1.0"
-source = "git+https://github.com/astroport-fi/astroport-core.git?branch=release#2144edd667f9686b5118c1132f416585e9cb99fc"
+version = "2.2.0"
+source = "git+https://github.com/astroport-fi/astroport-core.git?branch=release#4aa026f8c3a021a78386d8a034f425070dd06971"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -788,9 +788,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.92"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7434af0dc1cbd59268aa98b4c22c131c0584d2232f6fb166efb993e2832e896a"
+checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
 dependencies = [
  "itoa",
  "ryu",

--- a/contracts/controller/src/ibc.rs
+++ b/contracts/controller/src/ibc.rs
@@ -29,16 +29,14 @@ pub fn ibc_channel_open(
     }
     if channel.version != IBC_APP_VERSION {
         return Err(StdError::generic_err(format!(
-            "Must set version to `{}`",
-            IBC_APP_VERSION
+            "Must set version to `{IBC_APP_VERSION}`",
         )));
     }
 
     if let Some(counter_version) = msg.counterparty_version() {
         if counter_version != IBC_APP_VERSION {
             return Err(StdError::generic_err(format!(
-                "Counterparty version must be `{}`",
-                IBC_APP_VERSION
+                "Counterparty version must be `{IBC_APP_VERSION}`"
             )));
         }
     }
@@ -59,8 +57,7 @@ pub fn ibc_channel_connect(
     if let Some(counter_version) = msg.counterparty_version() {
         if counter_version != IBC_APP_VERSION {
             return Err(StdError::generic_err(format!(
-                "Counterparty version must be `{}`",
-                IBC_APP_VERSION
+                "Counterparty version must be `{IBC_APP_VERSION}`"
             )));
         }
     }

--- a/contracts/satellite/src/ibc.rs
+++ b/contracts/satellite/src/ibc.rs
@@ -42,16 +42,14 @@ pub fn ibc_channel_open(
     }
     if channel.version != IBC_APP_VERSION {
         return Err(StdError::generic_err(format!(
-            "Must set version to `{}`",
-            IBC_APP_VERSION
+            "Must set version to `{IBC_APP_VERSION}`"
         )));
     }
 
     if let Some(counter_version) = msg.counterparty_version() {
         if counter_version != IBC_APP_VERSION {
             return Err(StdError::generic_err(format!(
-                "Counterparty version must be `{}`",
-                IBC_APP_VERSION
+                "Counterparty version must be `{IBC_APP_VERSION}`"
             )));
         }
     }
@@ -72,8 +70,7 @@ pub fn ibc_channel_connect(
     if let Some(counter_version) = msg.counterparty_version() {
         if counter_version != IBC_APP_VERSION {
             return Err(ContractError::Std(StdError::generic_err(format!(
-                "Counterparty version must be `{}`",
-                IBC_APP_VERSION
+                "Counterparty version must be `{IBC_APP_VERSION}`"
             ))));
         }
     }

--- a/contracts/satellite/src/state.rs
+++ b/contracts/satellite/src/state.rs
@@ -31,7 +31,10 @@ impl Config {
             self.astro_denom = astro_denom;
         }
 
-        if params.gov_channel.is_some() && params.accept_new_connections.is_some() {
+        if params.gov_channel.is_some()
+            && params.accept_new_connections.is_some()
+            && params.accept_new_connections.unwrap()
+        {
             return Err(ContractError::UpdateChannelError {});
         }
 
@@ -46,7 +49,7 @@ impl Config {
         }
 
         if let Some(main_controller_addr) = params.main_controller_addr {
-            self.main_controller_port = format!("wasm.{}", main_controller_addr);
+            self.main_controller_port = format!("wasm.{main_controller_addr}");
         }
 
         if let Some(main_maker) = params.main_maker {


### PR DESCRIPTION
Added prohibition to specify two parameters at the same time: gov_channel & accept_new_connections