### PR TITLE
fix(controller_acks): Add handling of heartbeat acks and timeouts

### DIFF
--- a/.github/workflows/check_artifacts.yml
+++ b/.github/workflows/check_artifacts.yml
@@ -68,7 +68,7 @@ jobs:
           fail-on-cache-miss: true
       - name: Install cosmwasm-check
         # Uses --debug for compilation speed
-        run: cargo install --debug --version 1.3.1 cosmwasm-check
+        run: cargo install --debug --locked --version 1.3.1 cosmwasm-check
       - name: Cosmwasm check
         run: |
           cosmwasm-check $GITHUB_WORKSPACE/artifacts/*.wasm --available-capabilities staking,cosmwasm_1_1,neutron,iterator,stargate

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -720,7 +720,7 @@ dependencies = [
 
 [[package]]
 name = "ibc-controller"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "astro-satellite-package",
  "astroport-ibc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -720,7 +720,7 @@ dependencies = [
 
 [[package]]
 name = "ibc-controller"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "astro-satellite-package",
  "astroport-ibc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,7 +98,7 @@ dependencies = [
 
 [[package]]
 name = "astroport-ibc"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cosmwasm-schema",
 ]

--- a/contracts/controller/Cargo.toml
+++ b/contracts/controller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ibc-controller"
-version = "1.0.1"
+version = "1.1.0"
 authors = ["Astroport"]
 license = "Apache-2.0"
 description = "IBC controller contract intended to be hosted on the main chain."

--- a/contracts/controller/Cargo.toml
+++ b/contracts/controller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ibc-controller"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Astroport"]
 license = "Apache-2.0"
 description = "IBC controller contract intended to be hosted on the main chain."

--- a/contracts/controller/src/contract.rs
+++ b/contracts/controller/src/contract.rs
@@ -200,7 +200,7 @@ mod tests {
             proposal_id,
             messages: vec![proposal_msg.clone()],
         };
-        let resp = execute(deps.as_mut(), env.clone(), info, msg.clone()).unwrap();
+        let resp = execute(deps.as_mut(), env.clone(), info, msg).unwrap();
 
         assert_eq!(resp.messages.len(), 1);
         let real_timeout = IbcTimeout::with_timestamp(env.block.time.plus_seconds(360));
@@ -210,7 +210,7 @@ mod tests {
                 timeout,
                 data,
             }) if channel_id == channel_id && timeout == &real_timeout => {
-                let msg: SatelliteMsg = from_binary(&data).unwrap();
+                let msg: SatelliteMsg = from_binary(data).unwrap();
                 assert_eq!(
                     msg,
                     SatelliteMsg::ExecuteProposal {
@@ -223,7 +223,7 @@ mod tests {
         }
 
         let state = PROPOSAL_STATE
-            .load(deps.as_ref().storage, proposal_id.into())
+            .load(deps.as_ref().storage, proposal_id)
             .unwrap();
         assert_eq!(state, ProposalStatus::InProgress {})
     }

--- a/contracts/controller/src/ibc.rs
+++ b/contracts/controller/src/ibc.rs
@@ -5,11 +5,10 @@ use cosmwasm_std::{
     IbcReceiveResponse, StdError, StdResult, SubMsg,
 };
 
-use astro_satellite_package::IbcAckResult;
-use ibc_controller_package::astroport_governance::assembly::ProposalStatus;
-
-use ibc_controller_package::astroport_governance::assembly::ExecuteMsg as AssemblyExecuteMsg;
-use ibc_controller_package::IbcProposal;
+use astro_satellite_package::{IbcAckResult, SatelliteMsg};
+use ibc_controller_package::astroport_governance::assembly::{
+    ExecuteMsg as AssemblyExecuteMsg, ProposalStatus,
+};
 
 use crate::state::{CONFIG, LAST_ERROR, PROPOSAL_STATE};
 
@@ -99,33 +98,42 @@ pub fn ibc_packet_timeout(
     _env: Env,
     msg: IbcPacketTimeoutMsg,
 ) -> StdResult<IbcBasicResponse> {
-    let ibc_proposal: IbcProposal = from_binary(&msg.packet.data)?;
-    let new_status = PROPOSAL_STATE.update(deps.storage, ibc_proposal.id, |state| match state {
-        None => Err(StdError::generic_err(format!(
-            "Proposal {} was not executed via controller",
-            ibc_proposal.id
-        ))),
-        Some(state) => {
-            if state == ProposalStatus::InProgress {
-                Ok(ProposalStatus::Failed {})
-            } else {
-                Err(StdError::generic_err(format!(
-                    "Proposal id: {} state is already {}",
-                    ibc_proposal.id, state
-                )))
-            }
-        }
-    })?;
-    let config = CONFIG.load(deps.storage)?;
+    let mut res = IbcBasicResponse::new();
 
-    Ok(IbcBasicResponse::new()
-        .add_submessage(confirm_assembly(
-            &config.owner,
-            ibc_proposal.id,
-            new_status,
-        )?)
-        .add_attribute("action", "packet_timeout")
-        .add_attribute("proposal_id", ibc_proposal.id.to_string()))
+    let satellite_msg: SatelliteMsg = from_binary(&msg.packet.data)?;
+    match satellite_msg {
+        SatelliteMsg::ExecuteProposal { id, .. } => {
+            // The original packet was a proposal
+            let new_status = PROPOSAL_STATE.update(deps.storage, id, |state| match state {
+                None => Err(StdError::generic_err(format!(
+                    "Proposal {} was not executed via controller",
+                    id
+                ))),
+                Some(state) => {
+                    if state == ProposalStatus::InProgress {
+                        Ok(ProposalStatus::Failed {})
+                    } else {
+                        Err(StdError::generic_err(format!(
+                            "Proposal id: {} state is already {}",
+                            id, state
+                        )))
+                    }
+                }
+            })?;
+            let config = CONFIG.load(deps.storage)?;
+
+            res = res
+                .add_submessage(confirm_assembly(&config.owner, id, new_status)?)
+                .add_attribute("action", "proposal_timeout")
+                .add_attribute("proposal_id", id.to_string());
+        }
+        SatelliteMsg::Heartbeat {} => {
+            // The original packet was a heartbeat
+            // We don't do anything with the timeout for a heartbeat
+            res = res.add_attribute("action", "heartbeat_timeout")
+        }
+    }
+    Ok(res)
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
@@ -134,42 +142,51 @@ pub fn ibc_packet_ack(
     _env: Env,
     msg: IbcPacketAckMsg,
 ) -> StdResult<IbcBasicResponse> {
+    let mut res = IbcBasicResponse::new();
+
     let ibc_ack: IbcAckResult = from_binary(&msg.acknowledgement.data)?;
-    let ibc_proposal: IbcProposal = from_binary(&msg.original_packet.data)?;
-    let mut err_msg = "".to_string();
-    let new_status = PROPOSAL_STATE.update(deps.storage, ibc_proposal.id, |state| match state {
-        None => Err(StdError::generic_err(format!(
-            "Proposal {} was not executed via controller",
-            ibc_proposal.id
-        ))),
-        Some(state) => {
-            if state == ProposalStatus::InProgress {
-                match ibc_ack {
-                    IbcAckResult::Ok(_) => Ok(ProposalStatus::Executed {}),
-                    IbcAckResult::Error(err) => {
-                        err_msg = err;
-                        Ok(ProposalStatus::Failed {})
+    let satellite_msg: SatelliteMsg = from_binary(&msg.original_packet.data)?;
+    match satellite_msg {
+        SatelliteMsg::ExecuteProposal { id, .. } => {
+            // The original packet was a proposal
+            let mut err_msg = "".to_string();
+            let new_status = PROPOSAL_STATE.update(deps.storage, id, |state| match state {
+                None => Err(StdError::generic_err(format!(
+                    "Proposal {} was not executed via controller",
+                    id
+                ))),
+                Some(state) => {
+                    if state == ProposalStatus::InProgress {
+                        match ibc_ack {
+                            IbcAckResult::Ok(_) => Ok(ProposalStatus::Executed {}),
+                            IbcAckResult::Error(err) => {
+                                err_msg = err;
+                                Ok(ProposalStatus::Failed {})
+                            }
+                        }
+                    } else {
+                        Err(StdError::generic_err(format!(
+                            "Proposal id: {} state is already {}",
+                            id, state
+                        )))
                     }
                 }
-            } else {
-                Err(StdError::generic_err(format!(
-                    "Proposal id: {} state is already {}",
-                    ibc_proposal.id, state
-                )))
-            }
-        }
-    })?;
-    LAST_ERROR.save(deps.storage, &err_msg)?;
-    let config = CONFIG.load(deps.storage)?;
+            })?;
+            LAST_ERROR.save(deps.storage, &err_msg)?;
+            let config = CONFIG.load(deps.storage)?;
 
-    Ok(IbcBasicResponse::new()
-        .add_submessage(confirm_assembly(
-            &config.owner,
-            ibc_proposal.id,
-            new_status,
-        )?)
-        .add_attribute("action", "packet_ack")
-        .add_attribute("proposal_id", ibc_proposal.id.to_string()))
+            res = res
+                .add_submessage(confirm_assembly(&config.owner, id, new_status)?)
+                .add_attribute("action", "proposal_ack")
+                .add_attribute("proposal_id", id.to_string());
+        }
+        SatelliteMsg::Heartbeat {} => {
+            // The original packet was a heartbeat
+            // We don't do anything with the ack from a heartbeat
+            res = res.add_attribute("action", "heartbeat_ack")
+        }
+    }
+    Ok(res)
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
@@ -217,7 +234,7 @@ mod tests {
         // Ok acknowledgment
         let ack_msg = mock_ibc_packet_ack(
             channel_id,
-            &IbcProposal {
+            &SatelliteMsg::ExecuteProposal {
                 id: proposal_id,
                 messages: vec![],
             },
@@ -230,7 +247,7 @@ mod tests {
             .attributes
             .contains(&attr("proposal_id", proposal_id.to_string())));
         let state = PROPOSAL_STATE
-            .load(deps.as_ref().storage, proposal_id.into())
+            .load(deps.as_ref().storage, proposal_id)
             .unwrap();
         assert_eq!(state, ProposalStatus::Executed);
 
@@ -254,7 +271,7 @@ mod tests {
         execute(deps.as_mut(), env.clone(), info, msg).unwrap();
         let ack_msg = mock_ibc_packet_ack(
             channel_id,
-            &IbcProposal {
+            &SatelliteMsg::ExecuteProposal {
                 id: proposal_id,
                 messages: vec![],
             },
@@ -268,7 +285,7 @@ mod tests {
             .attributes
             .contains(&attr("proposal_id", proposal_id.to_string())));
         let state = PROPOSAL_STATE
-            .load(deps.as_ref().storage, proposal_id.into())
+            .load(deps.as_ref().storage, proposal_id)
             .unwrap();
         assert_eq!(state, ProposalStatus::Failed);
 
@@ -288,14 +305,14 @@ mod tests {
 
         // Previous proposal state was not changed
         let state = PROPOSAL_STATE
-            .load(deps.as_ref().storage, (proposal_id - 1).into())
+            .load(deps.as_ref().storage, proposal_id - 1)
             .unwrap();
         assert_eq!(state, ProposalStatus::Executed);
 
         // Proposal with unknown id
         let ack_msg = mock_ibc_packet_ack(
             channel_id,
-            &IbcProposal {
+            &SatelliteMsg::ExecuteProposal {
                 id: 128,
                 messages: vec![],
             },
@@ -322,8 +339,8 @@ mod tests {
         execute(deps.as_mut(), env.clone(), info, msg).unwrap();
 
         let timeout_msg = mock_ibc_packet_timeout(
-            &channel_id,
-            &IbcProposal {
+            channel_id,
+            &SatelliteMsg::ExecuteProposal {
                 id: proposal_id,
                 messages: vec![],
             },
@@ -335,7 +352,7 @@ mod tests {
             .contains(&attr("proposal_id", proposal_id.to_string())));
 
         let state = PROPOSAL_STATE
-            .load(deps.as_ref().storage, proposal_id.into())
+            .load(deps.as_ref().storage, proposal_id)
             .unwrap();
         assert_eq!(state, ProposalStatus::Failed);
 
@@ -366,14 +383,14 @@ mod tests {
 
         // timeout msg with unknown proposal id will fail
         let timeout_msg = mock_ibc_packet_timeout(
-            &channel_id,
-            &IbcProposal {
+            channel_id,
+            &SatelliteMsg::ExecuteProposal {
                 id: 128,
                 messages: vec![],
             },
         )
         .unwrap();
-        let err = ibc_packet_timeout(deps.as_mut(), env.clone(), timeout_msg).unwrap_err();
+        let err = ibc_packet_timeout(deps.as_mut(), env, timeout_msg).unwrap_err();
         assert_eq!(
             err,
             StdError::generic_err("Proposal 128 was not executed via controller")

--- a/contracts/satellite_neutron/.cargo/config
+++ b/contracts/satellite_neutron/.cargo/config
@@ -1,0 +1,4 @@
+[alias]
+wasm = "build --release --lib --target wasm32-unknown-unknown"
+unit-test = "test --lib"
+schema = "run --example satellite_neutron_schema"

--- a/packages/astroport-ibc/Cargo.toml
+++ b/packages/astroport-ibc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astroport-ibc"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
This PR fixes an issue where IBC acks and timeouts were not handled by the controller and resulted in errors shown to the relayer. This did not have any impact on the functionality of the controller or satellite.

The typical error looked like
```
message: "failed to execute message; message index: 1: acknowledge packet callback failed: on ack: Error parsing into type ibc_controller_package::IbcProposal: unknown field `heartbeat`, expected `id` or `messages`
```

Note: This was tested using Terra as controller and Neutron, Injective as satellites